### PR TITLE
Modify the version format in order to use setup.py

### DIFF
--- a/lomap/__init__.py
+++ b/lomap/__init__.py
@@ -27,4 +27,4 @@ from .algorithms.robust_multi_agent_optimal_run import robust_multi_agent_optima
 from .algorithms.value_iteration import *
 from .algorithms.inc_syn import *
 
-__version__ = (0, 1, 2)
+__version__ = ('0, 1, 2')

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import setup
 
 import lomap
 
-version = '.'.join(lomap.__version__)
+version = ','.join(lomap.__version__)
 
 setup(
     name='lomap',


### PR DESCRIPTION
There was an error when I try to do 
`python setup.py install`

After modifying both __init__.py and setup.py, the issue is resolved